### PR TITLE
Performance fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,13 @@
+pr: none
+trigger:
+  batch: true
+  branches:
+    include:
+      - '*'
+  tags:
+    include:
+      - '*'
+
 pool:
   vmImage: ubuntu-latest
 

--- a/src/Authentication/AuthenticatorFactory.php
+++ b/src/Authentication/AuthenticatorFactory.php
@@ -15,20 +15,17 @@ class AuthenticatorFactory
      */
     public function getAuthenticator(GuzzleClientFactory $clientFactory, $resource)
     {
-        $authenticators = [
-            ClientCredentialsEnvironmentAuthenticator::class,
-            ManagedCredentialsAuthenticator::class,
-        ];
-        foreach ($authenticators as $authenticatorClass) {
-            /** @var AuthenticatorInterface $authenticator */
-            $authenticator = new $authenticatorClass($clientFactory, $resource);
-            try {
-                $authenticator->checkUsability();
-                return $authenticator;
-            } catch (ClientException $e) {
-                $clientFactory->getLogger()->debug($authenticatorClass . ' is not usable: ' . $e->getMessage());
-            }
+        $authenticator = new ClientCredentialsEnvironmentAuthenticator($clientFactory, $resource);
+        try {
+            $authenticator->checkUsability();
+            return $authenticator;
+        } catch (ClientException $e) {
+            $clientFactory->getLogger()->debug(
+                'ClientCredentialsEnvironmentAuthenticator is not usable: ' . $e->getMessage()
+            );
         }
-        throw new ClientException('No suitable authentication method found.');
+        /* ManagedCredentialsAuthenticator checkUsability method has poor performance due to slow responses
+            from GET /metadata requests */
+        return new ManagedCredentialsAuthenticator($clientFactory, $resource);
     }
 }

--- a/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php
+++ b/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php
@@ -40,6 +40,8 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
     private $cloudName;
     /** @var string */
     private $resource;
+    /** @var string */
+    private $cachedToken;
 
     public function __construct(GuzzleClientFactory $clientFactory, $resource)
     {
@@ -84,9 +86,12 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
 
     public function getAuthenticationToken()
     {
-        $metadata = $this->getMetadata($this->armUrl);
-        $metadata = $this->processInstanceMetadata($metadata, $this->cloudName);
-        return $this->authenticate($metadata->getAuthenticationLoginEndpoint(), $this->resource);
+        if (empty($this->cachedToken)) {
+            $metadata = $this->getMetadata($this->armUrl);
+            $metadata = $this->processInstanceMetadata($metadata, $this->cloudName);
+            $this->cachedToken = $this->authenticate($metadata->getAuthenticationLoginEndpoint(), $this->resource);
+        }
+        return $this->cachedToken;
     }
 
     public function checkUsability()

--- a/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php
+++ b/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php
@@ -40,7 +40,7 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
     private $cloudName;
     /** @var string */
     private $resource;
-    /** @var string */
+    /** @var string|null */
     private $cachedToken;
 
     public function __construct(GuzzleClientFactory $clientFactory, $resource)

--- a/src/Authentication/ManagedCredentialsAuthenticator.php
+++ b/src/Authentication/ManagedCredentialsAuthenticator.php
@@ -16,7 +16,7 @@ class ManagedCredentialsAuthenticator implements AuthenticatorInterface
     private $logger;
     /** @var string */
     private $resource;
-    /** @var string */
+    /** @var string|null */
     private $cachedToken;
 
     const INSTANCE_METADATA_SERVICE_ENDPOINT = 'http://169.254.169.254/';

--- a/src/Authentication/ManagedCredentialsAuthenticator.php
+++ b/src/Authentication/ManagedCredentialsAuthenticator.php
@@ -16,6 +16,8 @@ class ManagedCredentialsAuthenticator implements AuthenticatorInterface
     private $logger;
     /** @var string */
     private $resource;
+    /** @var string */
+    private $cachedToken;
 
     const INSTANCE_METADATA_SERVICE_ENDPOINT = 'http://169.254.169.254/';
     const API_VERSION = '2019-11-01';
@@ -29,6 +31,9 @@ class ManagedCredentialsAuthenticator implements AuthenticatorInterface
 
     public function getAuthenticationToken()
     {
+        if (!empty($this->cachedToken)) {
+            return $this->cachedToken;
+        }
         try {
             $client = $this->clientFactory->getClient(self::INSTANCE_METADATA_SERVICE_ENDPOINT);
             $response = $client->get(
@@ -48,7 +53,8 @@ class ManagedCredentialsAuthenticator implements AuthenticatorInterface
                 throw new InvalidResponseException('Access token not provided in response: ' . json_encode($data));
             }
             $this->logger->info('Successfully authenticated using instance metadata.');
-            return (string) $data['access_token'];
+            $this->cachedToken = (string) $data['access_token'];
+            return $this->cachedToken;
         } catch (GuzzleException $e) {
             throw new ClientException('Failed to get authentication token: ' . $e->getMessage(), $e->getCode(), $e);
         }

--- a/src/GuzzleClientFactory.php
+++ b/src/GuzzleClientFactory.php
@@ -140,7 +140,9 @@ class GuzzleClientFactory
         return new GuzzleClient([
             'base_uri' => $url,
             'handler' => $handlerStack,
-            'headers' => ['User-Agent' => $options['userAgent'], 'Content-type' => 'application/json']
+            'headers' => ['User-Agent' => $options['userAgent'], 'Content-type' => 'application/json'],
+            'connect_timeout' => 10,
+            'timeout' => 120,
         ]);
     }
 }

--- a/tests/Authentication/ClientCredentialsEnvironmentAuthenticatorTest.php
+++ b/tests/Authentication/ClientCredentialsEnvironmentAuthenticatorTest.php
@@ -117,6 +117,9 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
         /** @var GuzzleClientFactory $factory */
         $auth = new ClientCredentialsEnvironmentAuthenticator($factory, 'https://vault.azure.net');
         $token = $auth->getAuthenticationToken();
+        // call second time, value is cached and no new request are made
+        $token2 = $auth->getAuthenticationToken();
+        self::assertSame($token, $token2);
         self::assertEquals('ey....ey', $token);
         self::assertCount(2, $requestHistory);
         /** @var Request $request */

--- a/tests/Authentication/ClientCredentialsEnvironmentAuthenticatorTest.php
+++ b/tests/Authentication/ClientCredentialsEnvironmentAuthenticatorTest.php
@@ -117,11 +117,12 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
         /** @var GuzzleClientFactory $factory */
         $auth = new ClientCredentialsEnvironmentAuthenticator($factory, 'https://vault.azure.net');
         $token = $auth->getAuthenticationToken();
+        self::assertCount(2, $requestHistory);
         // call second time, value is cached and no new request are made
         $token2 = $auth->getAuthenticationToken();
+        self::assertCount(2, $requestHistory);
         self::assertSame($token, $token2);
         self::assertEquals('ey....ey', $token);
-        self::assertCount(2, $requestHistory);
         /** @var Request $request */
         $request = $requestHistory[0]['request'];
         self::assertEquals('https://management.azure.com/metadata/endpoints?api-version=2020-01-01', $request->getUri()->__toString());

--- a/tests/Authentication/ManagedCredentialsAuthenticatorTest.php
+++ b/tests/Authentication/ManagedCredentialsAuthenticatorTest.php
@@ -49,10 +49,11 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
         /** @var GuzzleClientFactory $factory */
         $auth = new ManagedCredentialsAuthenticator($factory, 'https://vault.azure.net');
         $token = $auth->getAuthenticationToken();
+        self::assertCount(1, $requestHistory);
         // call second time, value is cached and no new request are made
         $token2 = $auth->getAuthenticationToken();
-        self::assertSame($token, $token2);
         self::assertCount(1, $requestHistory);
+        self::assertSame($token, $token2);
         /** @var Request $request */
         $request = $requestHistory[0]['request'];
         self::assertEquals('https://example.com/metadata/identity/oauth2/token?api-version=2019-11-01&format=text&resource=https://vault.azure.net', $request->getUri()->__toString());

--- a/tests/Authentication/ManagedCredentialsAuthenticatorTest.php
+++ b/tests/Authentication/ManagedCredentialsAuthenticatorTest.php
@@ -49,7 +49,9 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
         /** @var GuzzleClientFactory $factory */
         $auth = new ManagedCredentialsAuthenticator($factory, 'https://vault.azure.net');
         $token = $auth->getAuthenticationToken();
-        self::assertEquals('ey....ey', $token);
+        // call second time, value is cached and no new request are made
+        $token2 = $auth->getAuthenticationToken();
+        self::assertSame($token, $token2);
         self::assertCount(1, $requestHistory);
         /** @var Request $request */
         $request = $requestHistory[0]['request'];

--- a/tests/GuzzleClientFactoryTest.php
+++ b/tests/GuzzleClientFactoryTest.php
@@ -23,6 +23,8 @@ class GuzzleClientFactoryTest extends TestCase
         $client = $factory->getClient('http://example.com');
         self::assertInstanceOf(Client::class, $client);
         self::assertInstanceOf(NullLogger::class, $factory->getLogger());
+        self::assertEquals(120, $client->getConfig('timeout'));
+        self::assertEquals(10, $client->getConfig('connect_timeout'));
     }
 
     /**


### PR DESCRIPTION
fixes: https://keboola.atlassian.net/browse/PS-2857 & https://keboola.atlassian.net/browse/PS-2871
- checkUsability method is skipped on instance authorization, because the metadata responses can be very slow (multiple seconds)
- getAuthorizationToken value is cached for both auth methods
- added Guzzle timeouts to prevent freezing when Azure connection freezes
