### PR TITLE
Update installation instructions with functioning name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Only key encrypt and decrypt methods are currently implemented.
 
 ## Installation
 
-    composer require keboola/azure-key-vault-php-client
+    composer require keboola/azure-key-vault-client
     
 ## Usage
 


### PR DESCRIPTION
I tried to install with the given instructions but ran into a problem with the wrong name. I found the right one here: https://packagist.org/packages/keboola/azure-key-vault-client