### PR TITLE
PST-2407: Allow to override constants in ClientCredentialsEnvironmentAuthenticator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,13 @@ COPY ./docker/php/php.ini /usr/local/etc/php/php.ini
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
 
-RUN pecl install xdebug \
- && docker-php-ext-enable xdebug
+RUN pecl channel-update pecl.php.net && \
+    if [ "$(echo ${PHP_VERSION} | cut -d'.' -f1-2)" = "7.4" ]; then \
+        pecl install xdebug-3.1.6; \
+    else \
+        pecl install xdebug; \
+    fi && \
+    docker-php-ext-enable xdebug
 
 COPY composer.* ./
 RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG PHP_VERSION=7.4
-FROM php:${PHP_VERSION}-cli
+FROM php:8.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV XDEBUG_MODE=coverage
@@ -16,11 +15,7 @@ COPY ./docker/php/php.ini /usr/local/etc/php/php.ini
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
 
 RUN pecl channel-update pecl.php.net && \
-    if [ "$(echo ${PHP_VERSION} | cut -d'.' -f1-2)" = "7.4" ]; then \
-        pecl install xdebug-3.1.6; \
-    else \
-        pecl install xdebug; \
-    fi && \
+    pecl install xdebug && \
     docker-php-ext-enable xdebug
 
 COPY composer.* ./

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ $result = $client->encrypt(
 
 Run tests with:
 
-    docker-compose run --rm testsXX
+    docker compose run --rm testsXX
 
 where XX is PHP version (56 - 74), e.g.:
 
-    docker-compose run --rm tests70
+    docker compose run --rm tests70
 
 ### Resources Setup
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-- script: docker-compose build --build-arg PHP_VERSION=$PHP_VERSION ci && docker-compose run --rm ci
+- script: docker compose build --build-arg PHP_VERSION=$PHP_VERSION ci && docker compose run --rm ci
   displayName: 'Run Tests PHP 7.4'
   env:
     TEST_TENANT_ID: $(TEST_TENANT_ID)
@@ -27,7 +27,7 @@ steps:
     GIT_BRANCH: $(Build.SourceBranch)
     CC_TEST_REPORTER_ID: $(CC_TEST_REPORTER_ID)
 
-- script: docker-compose build --build-arg PHP_VERSION=$PHP_VERSION ci && docker-compose run --rm ci
+- script: docker compose build --build-arg PHP_VERSION=$PHP_VERSION ci && docker compose run --rm ci
   displayName: 'Run Tests PHP 8.1'
   env:
     TEST_TENANT_ID: $(TEST_TENANT_ID)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,8 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-- script: docker compose build --build-arg PHP_VERSION=$PHP_VERSION ci && docker compose run --rm ci
-  displayName: 'Run Tests PHP 7.4'
+- script: docker compose build ci && docker compose run --rm ci
+  displayName: 'Run Tests'
   env:
     TEST_TENANT_ID: $(TEST_TENANT_ID)
     TEST_CLIENT_ID: $(TEST_CLIENT_ID)
@@ -21,22 +21,6 @@ steps:
     TEST_KEY_VAULT_URL: $(TEST_KEY_VAULT_URL)
     TEST_KEY_NAME: $(TEST_KEY_VAULT_URL)
     TEST_KEY_VERSION: $(TEST_KEY_VERSION)
-    PHP_VERSION: 7.4
-    # For Codeclimate:
-    GIT_COMMIT_SHA: $(Build.SourceVersion)
-    GIT_BRANCH: $(Build.SourceBranch)
-    CC_TEST_REPORTER_ID: $(CC_TEST_REPORTER_ID)
-
-- script: docker compose build --build-arg PHP_VERSION=$PHP_VERSION ci && docker compose run --rm ci
-  displayName: 'Run Tests PHP 8.1'
-  env:
-    TEST_TENANT_ID: $(TEST_TENANT_ID)
-    TEST_CLIENT_ID: $(TEST_CLIENT_ID)
-    TEST_CLIENT_SECRET: $(TEST_CLIENT_SECRET)
-    TEST_KEY_VAULT_URL: $(TEST_KEY_VAULT_URL)
-    TEST_KEY_NAME: $(TEST_KEY_VAULT_URL)
-    TEST_KEY_VERSION: $(TEST_KEY_VERSION)
-    PHP_VERSION: 8.1
     # For Codeclimate:
     GIT_COMMIT_SHA: $(Build.SourceVersion)
     GIT_BRANCH: $(Build.SourceBranch)

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.5",
         "psr/log": "^1.1",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,7 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     </rule>
     <exclude-pattern>*/src/Kernel.php</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,6 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
-        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     </rule>
     <exclude-pattern>*/src/Kernel.php</exclude-pattern>
 </ruleset>

--- a/src/Authentication/AuthenticatorFactory.php
+++ b/src/Authentication/AuthenticatorFactory.php
@@ -17,7 +17,7 @@ class AuthenticatorFactory
             return $authenticator;
         } catch (ClientException $e) {
             $clientFactory->getLogger()->debug(
-                'ClientCredentialsEnvironmentAuthenticator is not usable: ' . $e->getMessage()
+                'ClientCredentialsEnvironmentAuthenticator is not usable: ' . $e->getMessage(),
             );
         }
         /* ManagedCredentialsAuthenticator checkUsability method has poor performance due to slow responses

--- a/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php
+++ b/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php
@@ -45,14 +45,14 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
         if (!$this->armUrl) {
             $this->armUrl = static::DEFAULT_ARM_URL;
             $this->logger->debug(
-                static::ENV_AZURE_AD_RESOURCE . ' environment variable is not specified, falling back to default.'
+                static::ENV_AZURE_AD_RESOURCE . ' environment variable is not specified, falling back to default.',
             );
         }
         $this->cloudName = (string) getenv(static::ENV_AZURE_ENVIRONMENT);
         if (!$this->cloudName) {
             $this->cloudName = static::DEFAULT_PUBLIC_CLOUD_NAME;
             $this->logger->debug(
-                static::ENV_AZURE_ENVIRONMENT . ' environment variable is not specified, falling back to default.'
+                static::ENV_AZURE_ENVIRONMENT . ' environment variable is not specified, falling back to default.',
             );
         }
 
@@ -72,7 +72,7 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
         }
         if (!$cloud) {
             throw new ClientException(
-                sprintf('Cloud "%s" not found in instance metadata: ' . json_encode($metadataArray), $cloudName)
+                sprintf('Cloud "%s" not found in instance metadata: ' . json_encode($metadataArray), $cloudName),
             );
         }
         return new ArmMetadata($cloud);
@@ -110,7 +110,7 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
             $metadata = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
             if (!is_array($metadata)) {
                 throw new InvalidResponseException(
-                    'Invalid metadata contents: ' . json_encode($metadata)
+                    'Invalid metadata contents: ' . json_encode($metadata),
                 );
             }
             return $metadata;
@@ -134,7 +134,7 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
                     'headers' => [
                         'Content-type' => 'application/x-www-form-urlencoded',
                     ],
-                ]
+                ],
             );
             $data = (array) json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
             if (empty($data['access_token']) || !is_scalar($data['access_token'])) {

--- a/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php
+++ b/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php
@@ -16,14 +16,14 @@ use Psr\Log\LoggerInterface;
 
 class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterface
 {
-    private const ENV_AZURE_AD_RESOURCE = 'AZURE_AD_RESOURCE';
-    private const ENV_AZURE_ENVIRONMENT = 'AZURE_ENVIRONMENT';
-    private const ENV_AZURE_TENANT_ID = 'AZURE_TENANT_ID';
-    private const ENV_AZURE_CLIENT_ID = 'AZURE_CLIENT_ID';
-    private const ENV_AZURE_CLIENT_SECRET = 'AZURE_CLIENT_SECRET';
+    protected const ENV_AZURE_AD_RESOURCE = 'AZURE_AD_RESOURCE';
+    protected const ENV_AZURE_ENVIRONMENT = 'AZURE_ENVIRONMENT';
+    protected const ENV_AZURE_TENANT_ID = 'AZURE_TENANT_ID';
+    protected const ENV_AZURE_CLIENT_ID = 'AZURE_CLIENT_ID';
+    protected const ENV_AZURE_CLIENT_SECRET = 'AZURE_CLIENT_SECRET';
 
-    private const DEFAULT_ARM_URL = 'https://management.azure.com/metadata/endpoints?api-version=2020-01-01';
-    private const DEFAULT_PUBLIC_CLOUD_NAME = 'AzureCloud';
+    protected const DEFAULT_ARM_URL = 'https://management.azure.com/metadata/endpoints?api-version=2020-01-01';
+    protected const DEFAULT_PUBLIC_CLOUD_NAME = 'AzureCloud';
 
     private Client $client;
     private LoggerInterface $logger;
@@ -40,25 +40,25 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
     public function __construct(GuzzleClientFactory $clientFactory, string $resource)
     {
         $this->logger = $clientFactory->getLogger();
-        $this->armUrl = (string) getenv(self::ENV_AZURE_AD_RESOURCE);
+        $this->armUrl = (string) getenv(static::ENV_AZURE_AD_RESOURCE);
         $this->resource = $resource;
         if (!$this->armUrl) {
-            $this->armUrl = self::DEFAULT_ARM_URL;
+            $this->armUrl = static::DEFAULT_ARM_URL;
             $this->logger->debug(
-                self::ENV_AZURE_AD_RESOURCE . ' environment variable is not specified, falling back to default.'
+                static::ENV_AZURE_AD_RESOURCE . ' environment variable is not specified, falling back to default.'
             );
         }
-        $this->cloudName = (string) getenv(self::ENV_AZURE_ENVIRONMENT);
+        $this->cloudName = (string) getenv(static::ENV_AZURE_ENVIRONMENT);
         if (!$this->cloudName) {
-            $this->cloudName = self::DEFAULT_PUBLIC_CLOUD_NAME;
+            $this->cloudName = static::DEFAULT_PUBLIC_CLOUD_NAME;
             $this->logger->debug(
-                self::ENV_AZURE_ENVIRONMENT . ' environment variable is not specified, falling back to default.'
+                static::ENV_AZURE_ENVIRONMENT . ' environment variable is not specified, falling back to default.'
             );
         }
 
-        $this->tenantId = (string) getenv(self::ENV_AZURE_TENANT_ID);
-        $this->clientId = (string) getenv(self::ENV_AZURE_CLIENT_ID);
-        $this->clientSecret = (string) getenv(self::ENV_AZURE_CLIENT_SECRET);
+        $this->tenantId = (string) getenv(static::ENV_AZURE_TENANT_ID);
+        $this->clientId = (string) getenv(static::ENV_AZURE_CLIENT_ID);
+        $this->clientSecret = (string) getenv(static::ENV_AZURE_CLIENT_SECRET);
         $this->client = $clientFactory->getClient($this->armUrl);
     }
 
@@ -91,7 +91,8 @@ class ClientCredentialsEnvironmentAuthenticator implements AuthenticatorInterfac
     public function checkUsability(): void
     {
         $errors = [];
-        foreach ([self::ENV_AZURE_TENANT_ID, self::ENV_AZURE_CLIENT_ID, self::ENV_AZURE_CLIENT_SECRET] as $envVar) {
+        $envVars = [static::ENV_AZURE_TENANT_ID, static::ENV_AZURE_CLIENT_ID, static::ENV_AZURE_CLIENT_SECRET];
+        foreach ($envVars as $envVar) {
             if (!getenv($envVar)) {
                 $errors[] = sprintf('Environment variable "%s" is not set.', $envVar);
             }

--- a/src/Authentication/ManagedCredentialsAuthenticator.php
+++ b/src/Authentication/ManagedCredentialsAuthenticator.php
@@ -39,13 +39,13 @@ class ManagedCredentialsAuthenticator implements AuthenticatorInterface
                 sprintf(
                     '/metadata/identity/oauth2/token?api-version=%s&format=text&resource=%s',
                     self::API_VERSION,
-                    $this->resource
+                    $this->resource,
                 ),
                 [
                     'headers' => [
                         'Metadata' => 'true',
                     ],
-                ]
+                ],
             );
             $data = (array) json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
             if (empty($data['access_token']) || !is_scalar($data['access_token'])) {
@@ -64,7 +64,7 @@ class ManagedCredentialsAuthenticator implements AuthenticatorInterface
         try {
             $client = $this->clientFactory->getClient(
                 self::INSTANCE_METADATA_SERVICE_ENDPOINT,
-                ['backoffMaxTries' => 1]
+                ['backoffMaxTries' => 1],
             );
             $client->get(
                 sprintf('/metadata?api-version=%s&format=text', self::API_VERSION),
@@ -72,7 +72,7 @@ class ManagedCredentialsAuthenticator implements AuthenticatorInterface
                     'headers' => [
                         'Metadata' => 'true',
                     ],
-                ]
+                ],
             );
         } catch (GuzzleException $e) {
             throw new ClientException('Instance metadata service not available: ' . $e->getMessage(), 0, $e);

--- a/src/Client.php
+++ b/src/Client.php
@@ -41,7 +41,7 @@ class Client
     public function __construct(
         GuzzleClientFactory $clientFactory,
         AuthenticatorFactory $authenticatorFactory,
-        string $vaultBaseUrl
+        string $vaultBaseUrl,
     ) {
         $handlerStack = HandlerStack::create();
         // Set handler to set authorization

--- a/src/Client.php
+++ b/src/Client.php
@@ -49,7 +49,7 @@ class Client
             function (RequestInterface $request) {
                 return $request
                     ->withHeader('Authorization', 'Bearer ' . $this->token);
-            }
+            },
         ));
         $this->logger = $clientFactory->getLogger();
         $this->guzzle = $clientFactory->getClient($vaultBaseUrl, ['handler' => $handlerStack]);
@@ -87,13 +87,13 @@ class Client
             throw new ClientException(
                 trim($data['error']['code'] . ': ' . $data['error']['message']),
                 $response->getStatusCode(),
-                $e
+                $e,
             );
         } elseif (!empty($data['error']) && is_scalar($data['error'])) {
             throw new ClientException(
                 trim('Request failed with error: ' . $data['error']),
                 $response->getStatusCode(),
-                $e
+                $e,
             );
         }
     }
@@ -104,7 +104,7 @@ class Client
             'POST',
             sprintf('keys/%s/%s/encrypt?api-version=%s', $keyName, $keyVersion, self::API_VERSION),
             [],
-            (string) json_encode($encryptRequest->getArray(), JSON_THROW_ON_ERROR)
+            (string) json_encode($encryptRequest->getArray(), JSON_THROW_ON_ERROR),
         );
         return new KeyOperationResult($this->sendRequest($request));
     }
@@ -115,7 +115,7 @@ class Client
             'POST',
             sprintf('keys/%s/%s/decrypt?api-version=%s', $keyName, $keyVersion, self::API_VERSION),
             [],
-            (string) json_encode($encryptRequest->getArray(), JSON_THROW_ON_ERROR)
+            (string) json_encode($encryptRequest->getArray(), JSON_THROW_ON_ERROR),
         );
         return new KeyOperationResult($this->sendRequest($request));
     }
@@ -126,7 +126,7 @@ class Client
             'PUT',
             sprintf('secrets/%s?api-version=%s', $secretName, self::API_VERSION),
             [],
-            (string) json_encode($setSecretRequest->getArray(), JSON_THROW_ON_ERROR)
+            (string) json_encode($setSecretRequest->getArray(), JSON_THROW_ON_ERROR),
         );
         return new SecretBundle($this->sendRequest($request));
     }
@@ -136,12 +136,12 @@ class Client
         if ($secretVersion === null) {
             $request = new Request(
                 'GET',
-                sprintf('secrets/%s?api-version=%s', $secretName, self::API_VERSION)
+                sprintf('secrets/%s?api-version=%s', $secretName, self::API_VERSION),
             );
         } else {
             $request = new Request(
                 'GET',
-                sprintf('secrets/%s/%s?api-version=%s', $secretName, $secretVersion, self::API_VERSION)
+                sprintf('secrets/%s/%s?api-version=%s', $secretName, $secretVersion, self::API_VERSION),
             );
         }
         return new SecretBundle($this->sendRequest($request));
@@ -151,7 +151,7 @@ class Client
     {
         $request = new Request(
             'GET',
-            sprintf('secrets/?maxresults=%s&api-version=%s', $maxResults, self::API_VERSION)
+            sprintf('secrets/?maxresults=%s&api-version=%s', $maxResults, self::API_VERSION),
         );
         return new SecretListResult($this->sendRequest($request));
     }
@@ -166,7 +166,7 @@ class Client
         while ($listResult->getNextLink()) {
             $request = new Request(
                 'GET',
-                $listResult->getNextLink()
+                $listResult->getNextLink(),
             );
             $listResult = new SecretListResult($this->sendRequest($request));
             $items = array_merge($items, $listResult->getValue());
@@ -178,7 +178,7 @@ class Client
     {
         $request = new Request(
             'DELETE',
-            sprintf('secrets/%s?api-version=%s', $secretName, self::API_VERSION)
+            sprintf('secrets/%s?api-version=%s', $secretName, self::API_VERSION),
         );
         return new DeletedSecretBundle($this->sendRequest($request));
     }

--- a/src/GuzzleClientFactory.php
+++ b/src/GuzzleClientFactory.php
@@ -43,14 +43,14 @@ class GuzzleClientFactory
         $validator = Validation::createValidator();
         $errors = $validator->validate($baseUrl, [new Url()]);
         $errors->addAll(
-            $validator->validate($baseUrl, [new NotBlank()])
+            $validator->validate($baseUrl, [new NotBlank()]),
         );
         $unknownOptions = array_diff(array_keys($options), self::ALLOWED_OPTIONS);
         if ($unknownOptions) {
             throw new ClientException(sprintf(
                 'Invalid options when creating client: %s. Valid options are: %s.',
                 implode(', ', $unknownOptions),
-                implode(', ', self::ALLOWED_OPTIONS)
+                implode(', ', self::ALLOWED_OPTIONS),
             ));
         }
 
@@ -102,8 +102,8 @@ class GuzzleClientFactory
                             (empty($response) ? 'No error' : $response->getBody()->getContents())
                             : $error->getMessage(),
                         $retries,
-                        $maxRetries
-                    )
+                        $maxRetries,
+                    ),
                 );
                 return true;
             }
@@ -124,8 +124,8 @@ class GuzzleClientFactory
                 $options['logger'],
                 new MessageFormatter(
                     '{hostname} {req_header_User-Agent} - [{ts}] "{method} {resource} {protocol}/{version}"' .
-                    ' {code} {res_header_Content-Length}'
-                )
+                    ' {code} {res_header_Content-Length}',
+                ),
             ));
         }
         // finally create the instance

--- a/src/GuzzleClientFactory.php
+++ b/src/GuzzleClientFactory.php
@@ -80,7 +80,7 @@ class GuzzleClientFactory
             int $retries,
             RequestInterface $request,
             ?ResponseInterface $response = null,
-            ?Throwable $error = null
+            ?Throwable $error = null,
         ) use ($maxRetries) {
             if ($retries >= $maxRetries) {
                 return false;

--- a/src/Requests/SecretAttributes.php
+++ b/src/Requests/SecretAttributes.php
@@ -35,7 +35,7 @@ class SecretAttributes
                 self::RECOVERY_LEVEL_RECOVERABLE,
                 self::RECOVERY_LEVEL_RECOVERABLE_PROTECTED_SUBSCRIPTION,
                 self::RECOVERY_LEVEL_RECOVERABLE_PURGEABLE,
-            ]
+            ],
         )) {
             throw new ClientException(sprintf('Invalid recovery level "%s"', $recoveryLevel));
         }
@@ -60,7 +60,7 @@ class SecretAttributes
             $attributes['exp'],
             $attributes['nbf'],
             $attributes['recoveryLevel'],
-            $attributes['updated']
+            $attributes['updated'],
         );
     }
 

--- a/src/Requests/SecretAttributes.php
+++ b/src/Requests/SecretAttributes.php
@@ -26,7 +26,7 @@ class SecretAttributes
         ?int $exp = null,
         ?int $nbf = null,
         ?string $recoveryLevel = null,
-        ?int $updated = null
+        ?int $updated = null,
     ) {
         if (!is_null($recoveryLevel) && !in_array(
             $recoveryLevel,

--- a/src/Requests/SetSecretRequest.php
+++ b/src/Requests/SetSecretRequest.php
@@ -15,7 +15,7 @@ class SetSecretRequest
         string $value,
         SecretAttributes $attributes,
         ?string $contentType = null,
-        ?array $tags = null
+        ?array $tags = null,
     ) {
         $this->value = $value;
         $this->attributes = $attributes;

--- a/src/Responses/ArmMetadata.php
+++ b/src/Responses/ArmMetadata.php
@@ -20,21 +20,21 @@ class ArmMetadata
             $this->name = (string) $data['name'];
         } else {
             throw new InvalidResponseException(
-                '"name" field not found in API response: ' . json_encode($data)
+                '"name" field not found in API response: ' . json_encode($data),
             );
         }
         if (!empty($data['suffixes']['keyVaultDns'])) {
             $this->keyVaultDns = (string) $data['suffixes']['keyVaultDns'];
         } else {
             throw new InvalidResponseException(
-                '"suffixes.keyVaultDns" field not found in API response: ' . json_encode($data)
+                '"suffixes.keyVaultDns" field not found in API response: ' . json_encode($data),
             );
         }
         if (!empty($data['authentication']['loginEndpoint'])) {
             $this->loginEndpoint = (string) $data['authentication']['loginEndpoint'];
         } else {
             throw new InvalidResponseException(
-                '"authentication.loginEndpoint" field not found in API response: ' . json_encode($data)
+                '"authentication.loginEndpoint" field not found in API response: ' . json_encode($data),
             );
         }
     }

--- a/src/Responses/SecretItem.php
+++ b/src/Responses/SecretItem.php
@@ -15,9 +15,6 @@ class SecretItem
     protected bool $managed;
     protected array $tags;
 
-    /**
-     * @param array $data
-     */
     public function __construct(array $data)
     {
         $this->validateData($data);

--- a/tests/Authentication/AuthenticationFactoryTest.php
+++ b/tests/Authentication/AuthenticationFactoryTest.php
@@ -26,7 +26,7 @@ class AuthenticationFactoryTest extends BaseTest
         $authenticationFactory = new AuthenticatorFactory();
         $authenticator = $authenticationFactory->getAuthenticator(
             new GuzzleClientFactory(new NullLogger()),
-            'https://vault.azure.net'
+            'https://vault.azure.net',
         );
         self::assertInstanceOf(ClientCredentialsEnvironmentAuthenticator::class, $authenticator);
     }
@@ -42,7 +42,7 @@ class AuthenticationFactoryTest extends BaseTest
             ->willThrowException(new GuzzleClientException(
                 'boo',
                 new Request('GET', '/foo/'),
-                new Response()
+                new Response(),
             ));
         $factoryMock = $this->createMock(GuzzleClientFactory::class);
         $factoryMock->method('getClient')->willReturn($mock);
@@ -54,7 +54,7 @@ class AuthenticationFactoryTest extends BaseTest
         self::assertInstanceOf(ManagedCredentialsAuthenticator::class, $authenticator);
         self::assertTrue($logger->hasDebugThatContains(
             'ClientCredentialsEnvironmentAuthenticator is not usable: ' .
-            'Environment variable "AZURE_TENANT_ID" is not set.'
+            'Environment variable "AZURE_TENANT_ID" is not set.',
         ));
     }
 

--- a/tests/Authentication/ClientCredentialsEnvironmentAuthenticatorTest.php
+++ b/tests/Authentication/ClientCredentialsEnvironmentAuthenticatorTest.php
@@ -22,7 +22,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
     {
         $authenticator = new ClientCredentialsEnvironmentAuthenticator(
             new GuzzleClientFactory(new NullLogger()),
-            'https://vault.azure.net'
+            'https://vault.azure.net',
         );
         putenv('AZURE_TENANT_ID=');
         self::expectException(ClientException::class);
@@ -34,7 +34,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
     {
         $authenticator = new ClientCredentialsEnvironmentAuthenticator(
             new GuzzleClientFactory(new NullLogger()),
-            'https://vault.azure.net'
+            'https://vault.azure.net',
         );
         putenv('AZURE_CLIENT_ID=');
         self::expectException(ClientException::class);
@@ -46,7 +46,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
     {
         $authenticator = new ClientCredentialsEnvironmentAuthenticator(
             new GuzzleClientFactory(new NullLogger()),
-            'https://vault.azure.net'
+            'https://vault.azure.net',
         );
         putenv('AZURE_CLIENT_SECRET=');
         self::expectException(ClientException::class);
@@ -59,14 +59,14 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
         $logger = new TestLogger();
         $authenticator = new ClientCredentialsEnvironmentAuthenticator(
             new GuzzleClientFactory($logger),
-            'https://vault.azure.net'
+            'https://vault.azure.net',
         );
         $authenticator->checkUsability();
         self::assertTrue($logger->hasDebugThatContains(
-            'AZURE_AD_RESOURCE environment variable is not specified, falling back to default.'
+            'AZURE_AD_RESOURCE environment variable is not specified, falling back to default.',
         ));
         self::assertTrue($logger->hasDebugThatContains(
-            'AZURE_ENVIRONMENT environment variable is not specified, falling back to default.'
+            'AZURE_ENVIRONMENT environment variable is not specified, falling back to default.',
         ));
     }
 
@@ -77,14 +77,14 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
         $logger = new TestLogger();
         $authenticator = new ClientCredentialsEnvironmentAuthenticator(
             new GuzzleClientFactory($logger),
-            'https://vault.azure.net'
+            'https://vault.azure.net',
         );
         $authenticator->checkUsability();
         self::assertFalse($logger->hasDebugThatContains(
-            'AZURE_AD_RESOURCE environment variable is not specified, falling back to default.'
+            'AZURE_AD_RESOURCE environment variable is not specified, falling back to default.',
         ));
         self::assertFalse($logger->hasDebugThatContains(
-            'AZURE_ENVIRONMENT environment variable is not specified, falling back to default.'
+            'AZURE_ENVIRONMENT environment variable is not specified, falling back to default.',
         ));
     }
 
@@ -95,11 +95,11 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
         putenv('AzureCloud=123');
         self::expectException(ClientException::class);
         self::expectExceptionMessage(
-            'Invalid options when creating client: Value "not-an-url" is invalid: This value is not a valid URL.'
+            'Invalid options when creating client: Value "not-an-url" is invalid: This value is not a valid URL.',
         );
         new ClientCredentialsEnvironmentAuthenticator(
             new GuzzleClientFactory($logger),
-            'https://vault.azure.net'
+            'https://vault.azure.net',
         );
     }
 
@@ -132,7 +132,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
         $request = $requestHistory[0]['request'];
         self::assertEquals(
             'https://management.azure.com/metadata/endpoints?api-version=2020-01-01',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         self::assertEquals('GET', $request->getMethod());
         self::assertEquals('Azure PHP Client', $request->getHeader('User-Agent')[0]);
@@ -146,7 +146,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
         self::assertEquals(
             // phpcs:ignore Generic.Files.LineLength
             'grant_type=client_credentials&client_id=client123&client_secret=secret123&resource=https%3A%2F%2Fvault.azure.net',
-            $request->getBody()->getContents()
+            $request->getBody()->getContents(),
         );
     }
 
@@ -162,7 +162,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                (string) json_encode($metadata)
+                (string) json_encode($metadata),
             ),
             new Response(
                 200,
@@ -175,7 +175,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
                     "not_before": "1589806552",
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -211,7 +211,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
         self::assertEquals(
             // phpcs:ignore Generic.Files.LineLength
             'grant_type=client_credentials&client_id=client123&client_secret=secret123&resource=https%3A%2F%2Fvault.azure.net',
-            $request->getBody()->getContents()
+            $request->getBody()->getContents(),
         );
     }
 
@@ -222,7 +222,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                (string) json_encode($this->getSampleArmMetadata())
+                (string) json_encode($this->getSampleArmMetadata()),
             ),
         ]);
 
@@ -247,12 +247,12 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
             new Response(
                 500,
                 ['Content-Type' => 'application/json'],
-                'boo'
+                'boo',
             ),
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                (string) json_encode($this->getSampleArmMetadata())
+                (string) json_encode($this->getSampleArmMetadata()),
             ),
             new Response(
                 200,
@@ -265,7 +265,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
                     "not_before": "1589806552",
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -289,7 +289,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                'boo'
+                'boo',
             ),
         ]);
 
@@ -314,7 +314,7 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                '"boo"'
+                '"boo"',
             ),
         ]);
 
@@ -339,12 +339,12 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                (string) json_encode($this->getSampleArmMetadata())
+                (string) json_encode($this->getSampleArmMetadata()),
             ),
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                '{"boo"}'
+                '{"boo"}',
             ),
         ]);
 
@@ -369,12 +369,12 @@ class ClientCredentialsEnvironmentAuthenticatorTest extends BaseTest
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                (string) json_encode($this->getSampleArmMetadata())
+                (string) json_encode($this->getSampleArmMetadata()),
             ),
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                '{"error": "boo"}'
+                '{"error": "boo"}',
             ),
         ]);
 

--- a/tests/Authentication/ManagedCredentialsAuthenticatorTest.php
+++ b/tests/Authentication/ManagedCredentialsAuthenticatorTest.php
@@ -31,7 +31,7 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
                     "not_before": "1589806552",
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ]);
 
@@ -56,7 +56,7 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
         self::assertEquals(
             // phpcs:ignore Generic.Files.LineLength
             'https://example.com/metadata/identity/oauth2/token?api-version=2019-11-01&format=text&resource=https://vault.azure.net',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         self::assertEquals('GET', $request->getMethod());
         self::assertEquals('Azure PHP Client', $request->getHeader('User-Agent')[0]);
@@ -72,7 +72,7 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
                 ['Content-Type' => 'application/json'],
                 '{
                     "foo": "bar"
-                }'
+                }',
             ),
         ]);
 
@@ -99,7 +99,7 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
                 ['Content-Type' => 'application/json'],
                 '{
                     "bar"
-                }'
+                }',
             ),
         ]);
 
@@ -124,7 +124,7 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                ''
+                '',
             ),
         ]);
 
@@ -144,7 +144,7 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
         $request = $requestHistory[0]['request'];
         self::assertEquals(
             'https://example.com/metadata?api-version=2019-11-01&format=text',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         self::assertEquals('GET', $request->getMethod());
         self::assertEquals('Azure PHP Client', $request->getHeader('User-Agent')[0]);
@@ -158,12 +158,12 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
             new Response(
                 500,
                 ['Content-Type' => 'application/json'],
-                ''
+                '',
             ),
             new Response(
                 500,
                 ['Content-Type' => 'application/json'],
-                ''
+                '',
             ),
         ]);
 
@@ -179,7 +179,7 @@ class ManagedCredentialsAuthenticatorTest extends TestCase
         $auth = new ManagedCredentialsAuthenticator($factory, 'https://vault.azure.net');
         self::expectExceptionMessage(
             // phpcs:ignore Generic.Files.LineLength
-            'Instance metadata service not available: Server error: `GET https://example.com/metadata?api-version=2019-11-01&format=text` resulted in a `500 Internal Server Error`'
+            'Instance metadata service not available: Server error: `GET https://example.com/metadata?api-version=2019-11-01&format=text` resulted in a `500 Internal Server Error`',
         );
         self::expectException(ClientException::class);
         $auth->checkUsability();

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -63,7 +63,7 @@ abstract class BaseTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                (string) json_encode($this->getSampleArmMetadata())
+                (string) json_encode($this->getSampleArmMetadata()),
             ),
             new Response(
                 200,
@@ -76,7 +76,7 @@ abstract class BaseTest extends TestCase
                     "not_before": "1589806552",
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
         ];
     }

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -26,7 +26,7 @@ class ClientFunctionalTest extends TestCase
         foreach ($envs as $env) {
             if (!getenv($env)) {
                 throw new RuntimeException(
-                    sprintf('At least one of %s environment variables is empty.', implode(', ', $envs))
+                    sprintf('At least one of %s environment variables is empty.', implode(', ', $envs)),
                 );
             }
         }
@@ -42,7 +42,7 @@ class ClientFunctionalTest extends TestCase
         $client = new Client(
             new GuzzleClientFactory(new NullLogger()),
             new AuthenticatorFactory(),
-            (string) getenv('TEST_KEY_VAULT_URL')
+            (string) getenv('TEST_KEY_VAULT_URL'),
         );
         foreach ($client->getAllSecrets() as $secret) {
             $client->deleteSecret($secret->getName());
@@ -56,12 +56,12 @@ class ClientFunctionalTest extends TestCase
         $client = new Client(
             new GuzzleClientFactory($logger),
             new AuthenticatorFactory(),
-            (string) getenv('TEST_KEY_VAULT_URL')
+            (string) getenv('TEST_KEY_VAULT_URL'),
         );
         $result = $client->encrypt(
             new EncryptRequest(EncryptDecryptRequest::RSA_OAEP_256, $payload),
             (string) getenv('TEST_KEY_NAME'),
-            (string) getenv('TEST_KEY_VERSION')
+            (string) getenv('TEST_KEY_VERSION'),
         );
         self::assertNotEquals($payload, $result->getValue(false));
         self::assertNotEquals($payload, $result->getValue(true));
@@ -69,18 +69,18 @@ class ClientFunctionalTest extends TestCase
         self::assertEquals(
             getenv('TEST_KEY_VAULT_URL') . '/keys/' . getenv('TEST_KEY_NAME') .
             '/' . getenv('TEST_KEY_VERSION'),
-            $result->getKid()
+            $result->getKid(),
         );
         $result = $client->decrypt(
             new DecryptRequest(EncryptDecryptRequest::RSA_OAEP_256, $result->getValue(false)),
             (string) getenv('TEST_KEY_NAME'),
-            (string) getenv('TEST_KEY_VERSION')
+            (string) getenv('TEST_KEY_VERSION'),
         );
         self::assertEquals($payload, $result->getValue(true));
         self::assertEquals(
             getenv('TEST_KEY_VAULT_URL') . '/keys/' . getenv('TEST_KEY_NAME') .
             '/' . getenv('TEST_KEY_VERSION'),
-            $result->getKid()
+            $result->getKid(),
         );
     }
 
@@ -91,11 +91,11 @@ class ClientFunctionalTest extends TestCase
         $client = new Client(
             new GuzzleClientFactory($logger),
             new AuthenticatorFactory(),
-            (string) getenv('TEST_KEY_VAULT_URL')
+            (string) getenv('TEST_KEY_VAULT_URL'),
         );
         $result = $client->setSecret(
             new SetSecretRequest($payload, new SecretAttributes(), null, ['a' => 'b', 'c' => 'd']),
-            uniqid('my-secret')
+            uniqid('my-secret'),
         );
         self::assertEquals($payload, $result->getValue());
 
@@ -111,17 +111,17 @@ class ClientFunctionalTest extends TestCase
         $client = new Client(
             new GuzzleClientFactory($logger),
             new AuthenticatorFactory(),
-            (string) getenv('TEST_KEY_VAULT_URL')
+            (string) getenv('TEST_KEY_VAULT_URL'),
         );
         $secretName = uniqid('my-secret');
         $client->setSecret(
             new SetSecretRequest($payload, new SecretAttributes(), null, ['a' => 'b', 'c' => 'd']),
-            $secretName
+            $secretName,
         );
         $payload = 'test';
         $result = $client->setSecret(
             new SetSecretRequest($payload, new SecretAttributes(), null, ['a' => 'b', 'c' => 'd']),
-            $secretName
+            $secretName,
         );
         self::assertEquals($payload, $result->getValue());
 
@@ -135,7 +135,7 @@ class ClientFunctionalTest extends TestCase
         $client = new Client(
             new GuzzleClientFactory(new NullLogger()),
             new AuthenticatorFactory(),
-            (string) getenv('TEST_KEY_VAULT_URL')
+            (string) getenv('TEST_KEY_VAULT_URL'),
         );
         $client->setSecret(new SetSecretRequest('test1', new SecretAttributes()), uniqid('test-secret1'));
         $client->setSecret(new SetSecretRequest('test2', new SecretAttributes()), uniqid('test-secret2'));

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -25,7 +25,7 @@ class ClientTest extends BaseTest
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                (string) json_encode($this->getSampleArmMetadata())
+                (string) json_encode($this->getSampleArmMetadata()),
             ),
             new Response(
                 200,
@@ -38,7 +38,7 @@ class ClientTest extends BaseTest
                     "not_before": "1589806552",
                     "resource": "https://vault.azure.net",
                     "access_token": "ey....ey"
-                }'
+                }',
             ),
             new Response(
                 200,
@@ -46,7 +46,7 @@ class ClientTest extends BaseTest
                 '{
                     "kid": "https://my-test.vault.azure.net/keys/test-key/test-version",
                     "value": "someEncryptedValue"
-                }'
+                }',
             ),
         ]);
 
@@ -68,7 +68,7 @@ class ClientTest extends BaseTest
         $result = $client->encrypt(
             new EncryptRequest('RSA1_5', 'test'),
             'test-key',
-            'test-version'
+            'test-version',
         );
         self::assertNotEquals('test', $result->getValue(true));
         self::assertNotEquals('test', $result->getValue(false));
@@ -79,19 +79,19 @@ class ClientTest extends BaseTest
         $request = $requestHistory[0]['request'];
         self::assertEquals(
             'https://management.azure.com/metadata/endpoints?api-version=2020-01-01',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         /** @var Request $request */
         $request = $requestHistory[1]['request'];
         self::assertEquals(
             'https://login.windows.net/tenant123/oauth2/token',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         /** @var Request $request */
         $request = $requestHistory[2]['request'];
         self::assertEquals(
             'https://example.com/keys/test-key/test-version/encrypt?api-version=7.0',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         self::assertEquals('POST', $request->getMethod());
         self::assertEquals('Azure PHP Client', $request->getHeader('User-Agent')[0]);
@@ -111,8 +111,8 @@ class ClientTest extends BaseTest
             [new Response(
                 400,
                 ['Content-Type' => 'application/json'],
-                $body
-            )]
+                $body,
+            )],
         ));
 
         $requestHistory = [];
@@ -135,7 +135,7 @@ class ClientTest extends BaseTest
             $client->encrypt(
                 new EncryptRequest('RSA1_5', 'test'),
                 'test-key',
-                'test-version'
+                'test-version',
             );
             self::fail('Must throw exception');
         } catch (ClientException $e) {
@@ -149,17 +149,17 @@ class ClientTest extends BaseTest
         $request = $requestHistory[0]['request'];
         self::assertEquals(
             'https://management.azure.com/metadata/endpoints?api-version=2020-01-01',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         $request = $requestHistory[1]['request'];
         self::assertEquals(
             'https://login.windows.net/tenant123/oauth2/token',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         $request = $requestHistory[2]['request'];
         self::assertEquals(
             'https://example.com/keys/test-key/test-version/encrypt?api-version=7.0',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
     }
 
@@ -207,7 +207,7 @@ class ClientTest extends BaseTest
                             "code": "Boo",
                             "message": "Cooties!"
                         }
-                    }'
+                    }',
                 )],
                 array_fill(0, 2, new Response(
                     500,
@@ -217,9 +217,9 @@ class ClientTest extends BaseTest
                             "code": "Boo",
                             "message": "Cooties!"
                         }
-                    }'
-                ))
-            )
+                    }',
+                )),
+            ),
         );
 
         $requestHistory = [];
@@ -242,7 +242,7 @@ class ClientTest extends BaseTest
             $client->encrypt(
                 new EncryptRequest('RSA1_5', 'test'),
                 'test-key',
-                'test-version'
+                'test-version',
             );
             self::fail('Must throw exception');
         } catch (ClientException $e) {
@@ -256,27 +256,27 @@ class ClientTest extends BaseTest
         $request = $requestHistory[0]['request'];
         self::assertEquals(
             'https://management.azure.com/metadata/endpoints?api-version=2020-01-01',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         $request = $requestHistory[1]['request'];
         self::assertEquals(
             'https://login.windows.net/tenant123/oauth2/token',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         $request = $requestHistory[2]['request'];
         self::assertEquals(
             'https://example.com/keys/test-key/test-version/encrypt?api-version=7.0',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         $request = $requestHistory[3]['request'];
         self::assertEquals(
             'https://example.com/keys/test-key/test-version/encrypt?api-version=7.0',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
         $request = $requestHistory[4]['request'];
         self::assertEquals(
             'https://example.com/keys/test-key/test-version/encrypt?api-version=7.0',
-            $request->getUri()->__toString()
+            $request->getUri()->__toString(),
         );
     }
 }

--- a/tests/GuzzleClientFactoryTest.php
+++ b/tests/GuzzleClientFactoryTest.php
@@ -84,7 +84,7 @@ class GuzzleClientFactoryTest extends TestCase
             new Response(
                 200,
                 [],
-                'boo'
+                'boo',
             ),
         ]);
 
@@ -96,7 +96,7 @@ class GuzzleClientFactoryTest extends TestCase
         $factory = new GuzzleClientFactory(new NullLogger());
         $client = $factory->getClient(
             'https://example.com',
-            ['handler' => $stack, 'userAgent' => 'test-client']
+            ['handler' => $stack, 'userAgent' => 'test-client'],
         );
         $client->get('');
 
@@ -116,7 +116,7 @@ class GuzzleClientFactoryTest extends TestCase
             new Response(
                 403,
                 [],
-                'boo'
+                'boo',
             ),
         ]);
 
@@ -128,7 +128,7 @@ class GuzzleClientFactoryTest extends TestCase
         $factory = new GuzzleClientFactory(new NullLogger());
         $client = $factory->getClient(
             'https://example.com',
-            ['handler' => $stack, 'userAgent' => 'test-client']
+            ['handler' => $stack, 'userAgent' => 'test-client'],
         );
         try {
             $client->get('');
@@ -136,7 +136,7 @@ class GuzzleClientFactoryTest extends TestCase
         } catch (GuzzleClientException $e) {
             self::assertStringContainsString(
                 'Client error: `GET https://example.com` resulted in a `403 Forbidden` response',
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -152,17 +152,17 @@ class GuzzleClientFactoryTest extends TestCase
             new Response(
                 501,
                 [],
-                'boo'
+                'boo',
             ),
             new Response(
                 501,
                 [],
-                'boo'
+                'boo',
             ),
             new Response(
                 501,
                 [],
-                'boo'
+                'boo',
             ),
         ]);
 
@@ -174,7 +174,7 @@ class GuzzleClientFactoryTest extends TestCase
         $factory = new GuzzleClientFactory(new NullLogger());
         $client = $factory->getClient(
             'https://example.com',
-            ['handler' => $stack, 'userAgent' => 'test-client', 'backoffMaxTries' => 2]
+            ['handler' => $stack, 'userAgent' => 'test-client', 'backoffMaxTries' => 2],
         );
         try {
             $client->get('');
@@ -182,7 +182,7 @@ class GuzzleClientFactoryTest extends TestCase
         } catch (ServerException $e) {
             self::assertStringContainsString(
                 'Server error: `GET https://example.com` resulted in a `501 Not Implemented`',
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -202,17 +202,17 @@ class GuzzleClientFactoryTest extends TestCase
             new Response(
                 501,
                 [],
-                'boo'
+                'boo',
             ),
             new Response(
                 501,
                 [],
-                'boo'
+                'boo',
             ),
             new Response(
                 200,
                 [],
-                'boo'
+                'boo',
             ),
         ]);
 
@@ -224,7 +224,7 @@ class GuzzleClientFactoryTest extends TestCase
         $factory = new GuzzleClientFactory($logger);
         $client = $factory->getClient(
             'https://example.com',
-            ['handler' => $stack, 'userAgent' => 'test-client', 'backoffMaxTries' => 2]
+            ['handler' => $stack, 'userAgent' => 'test-client', 'backoffMaxTries' => 2],
         );
         $client->get('');
 
@@ -237,7 +237,7 @@ class GuzzleClientFactoryTest extends TestCase
         $request = $requestHistory[2]['request'];
         self::assertEquals('https://example.com', $request->getUri()->__toString());
         self::assertTrue($logger->hasWarningThatContains(
-            'Request failed (Server error: `GET https://example.com` resulted in a `501 Not Implemented`'
+            'Request failed (Server error: `GET https://example.com` resulted in a `501 Not Implemented`',
         ));
         self::assertTrue($logger->hasWarningThatContains('retrying (1 of 2)'));
     }
@@ -248,17 +248,17 @@ class GuzzleClientFactoryTest extends TestCase
             new Response(
                 429,
                 [],
-                'boo'
+                'boo',
             ),
             new Response(
                 429,
                 [],
-                'boo'
+                'boo',
             ),
             new Response(
                 200,
                 [],
-                'boo'
+                'boo',
             ),
         ]);
 
@@ -270,7 +270,7 @@ class GuzzleClientFactoryTest extends TestCase
         $factory = new GuzzleClientFactory($logger);
         $client = $factory->getClient(
             'https://example.com',
-            ['handler' => $stack, 'userAgent' => 'test-client', 'backoffMaxTries' => 2]
+            ['handler' => $stack, 'userAgent' => 'test-client', 'backoffMaxTries' => 2],
         );
         $client->get('');
 
@@ -283,7 +283,7 @@ class GuzzleClientFactoryTest extends TestCase
         $request = $requestHistory[2]['request'];
         self::assertEquals('https://example.com', $request->getUri()->__toString());
         self::assertTrue($logger->hasWarningThatContains(
-            'Request failed (Client error: `GET https://example.com` resulted in a `429 Too Many Requests`'
+            'Request failed (Client error: `GET https://example.com` resulted in a `429 Too Many Requests`',
         ));
         self::assertTrue($logger->hasWarningThatContains('retrying (1 of 2)'));
     }

--- a/tests/Requests/EncryptDecryptRequestTest.php
+++ b/tests/Requests/EncryptDecryptRequestTest.php
@@ -19,7 +19,7 @@ class EncryptDecryptRequestTest extends TestCase
                 'alg' => 'RSA-OAEP',
                 'value' => 'Zm9v',
             ],
-            $request->getArray()
+            $request->getArray(),
         );
     }
 
@@ -38,7 +38,7 @@ class EncryptDecryptRequestTest extends TestCase
                 'alg' => 'RSA-OAEP',
                 'value' => 'foo',
             ],
-            $request->getArray()
+            $request->getArray(),
         );
     }
 

--- a/tests/Requests/SecretAttributesTest.php
+++ b/tests/Requests/SecretAttributesTest.php
@@ -28,7 +28,7 @@ class SecretAttributesTest extends TestCase
                 'recoveryLevel' => 'Purgeable',
                 'updated' => 1590586216,
             ],
-            $attributes->getArray()
+            $attributes->getArray(),
         );
     }
 
@@ -64,7 +64,7 @@ class SecretAttributesTest extends TestCase
                 'recoveryLevel' => 'Purgeable',
                 'updated' => 1590586216,
             ],
-            $attributes->getArray()
+            $attributes->getArray(),
         );
     }
 }

--- a/tests/Requests/SetSecretRequestTest.php
+++ b/tests/Requests/SetSecretRequestTest.php
@@ -22,7 +22,7 @@ class SetSecretRequestTest extends TestCase
                 'contentType' => 'plain',
                 'tags' => ['a' => 'b'],
             ],
-            $request->getArray()
+            $request->getArray(),
         );
     }
 
@@ -33,7 +33,7 @@ class SetSecretRequestTest extends TestCase
             [
                 'value' => 'so-secret',
             ],
-            $request->getArray()
+            $request->getArray(),
         );
     }
 }

--- a/tests/Responses/DeletedSecretBundleTest.php
+++ b/tests/Responses/DeletedSecretBundleTest.php
@@ -43,7 +43,7 @@ class DeletedSecretBundleTest extends TestCase
             'recoveryLevel' => 'Purgeable',
             'updated' => 1590586213,
             ],
-            $deletedSecretBundle->getAttributes()->getArray()
+            $deletedSecretBundle->getAttributes()->getArray(),
         );
         self::assertEquals('plain', $deletedSecretBundle->getContentType());
         self::assertEquals('https://test.vault.azure.net/secrets/foo/53af0dad94f248', $deletedSecretBundle->getId());
@@ -54,7 +54,7 @@ class DeletedSecretBundleTest extends TestCase
                 'a' => 'b',
                 'c' => 'd',
             ],
-            $deletedSecretBundle->getTags()
+            $deletedSecretBundle->getTags(),
         );
         self::assertEquals('so-secret', $deletedSecretBundle->getValue());
         self::assertEquals('foo', $deletedSecretBundle->getName());
@@ -93,7 +93,7 @@ class DeletedSecretBundleTest extends TestCase
             'recoveryLevel' => 'Purgeable',
             'updated' => 1590586213,
             ],
-            $deletedSecretBundle->getAttributes()->getArray()
+            $deletedSecretBundle->getAttributes()->getArray(),
         );
         self::assertEquals('https://test.vault.azure.net/secrets/foo/53af0dad94f248', $deletedSecretBundle->getId());
         self::assertEquals('foo', $deletedSecretBundle->getName());

--- a/tests/Responses/SecretBundleTest.php
+++ b/tests/Responses/SecretBundleTest.php
@@ -40,7 +40,7 @@ class SecretBundleTest extends TestCase
                 'recoveryLevel' => 'Purgeable',
                 'updated' => 1590586213,
             ],
-            $secretBundle->getAttributes()->getArray()
+            $secretBundle->getAttributes()->getArray(),
         );
         self::assertEquals('plain', $secretBundle->getContentType());
         self::assertEquals('https://test.vault.azure.net/secrets/foo/53af0dad94f248', $secretBundle->getId());
@@ -51,7 +51,7 @@ class SecretBundleTest extends TestCase
                 'a' => 'b',
                 'c' => 'd',
             ],
-            $secretBundle->getTags()
+            $secretBundle->getTags(),
         );
         self::assertEquals('so-secret', $secretBundle->getValue());
         self::assertEquals('foo', $secretBundle->getName());

--- a/tests/Responses/SecretItemTest.php
+++ b/tests/Responses/SecretItemTest.php
@@ -38,7 +38,7 @@ class SecretItemTest extends TestCase
             'recoveryLevel' => 'Purgeable',
             'updated' => 1590586213,
             ],
-            $secretItem->getAttributes()->getArray()
+            $secretItem->getAttributes()->getArray(),
         );
         self::assertEquals('plain', $secretItem->getContentType());
         self::assertEquals('https://test.vault.azure.net/secrets/foo', $secretItem->getId());
@@ -48,7 +48,7 @@ class SecretItemTest extends TestCase
                 'a' => 'b',
                 'c' => 'd',
             ],
-            $secretItem->getTags()
+            $secretItem->getTags(),
         );
         self::assertEquals('foo', $secretItem->getName());
     }

--- a/tests/Responses/SecretListResultTest.php
+++ b/tests/Responses/SecretListResultTest.php
@@ -61,7 +61,7 @@ class SecretListResultTest extends TestCase
                 'recoveryLevel' => 'Purgeable',
                 'updated' => 1590586213,
             ],
-            $secretItem->getAttributes()->getArray()
+            $secretItem->getAttributes()->getArray(),
         );
         self::assertEquals('plain', $secretItem->getContentType());
         self::assertEquals('https://test.vault.azure.net/secrets/foo', $secretItem->getId());
@@ -71,7 +71,7 @@ class SecretListResultTest extends TestCase
                 'a' => 'b',
                 'c' => 'd',
             ],
-            $secretItem->getTags()
+            $secretItem->getTags(),
         );
         self::assertEquals('foo', $secretItem->getName());
         $secretItem = $secretItemList->getValue()[1];
@@ -84,7 +84,7 @@ class SecretListResultTest extends TestCase
                 'recoveryLevel' => 'Recoverable',
                 'updated' => 290586213,
             ],
-            $secretItem->getAttributes()->getArray()
+            $secretItem->getAttributes()->getArray(),
         );
         self::assertEquals('clumsy', $secretItem->getContentType());
         self::assertEquals('https://test.vault.azure.net/secrets/bar', $secretItem->getId());
@@ -94,7 +94,7 @@ class SecretListResultTest extends TestCase
                 'd' => 'c',
                 'b' => 'a',
             ],
-            $secretItem->getTags()
+            $secretItem->getTags(),
         );
         self::assertEquals('bar', $secretItem->getName());
         self::assertEquals('https://example.com/next', $secretItemList->getNextLink());


### PR DESCRIPTION
Part of https://keboola.atlassian.net/browse/PST-2407

Change the visibility of the constants to `protected` in [ClientCredentialsEnvironmentAuthenticator](https://github.com/keboola/azure-key-vault-php-client/blob/db3dc38a0e890b1308dbf92ea6f790e71b6b3957/src/Authentication/ClientCredentialsEnvironmentAuthenticator.php) so it can be overridden in an extending class