### PR TITLE
feat: Add support for Federated OIDC token auth

### DIFF
--- a/src/Authentication/AuthenticatorFactory.php
+++ b/src/Authentication/AuthenticatorFactory.php
@@ -20,6 +20,17 @@ class AuthenticatorFactory
                 'ClientCredentialsEnvironmentAuthenticator is not usable: ' . $e->getMessage(),
             );
         }
+
+        $authenticator = new FederatedTokenAuthenticator($clientFactory, $resource);
+        try {
+            $authenticator->checkUsability();
+            return $authenticator;
+        } catch (ClientException $e) {
+            $clientFactory->getLogger()->debug(
+                'FederatedTokenAuthenticator is not usable: ' . $e->getMessage(),
+            );
+        }
+
         /* ManagedCredentialsAuthenticator checkUsability method has poor performance due to slow responses
             from GET /metadata requests */
         return new ManagedCredentialsAuthenticator($clientFactory, $resource);

--- a/src/Authentication/FederatedTokenAuthenticator.php
+++ b/src/Authentication/FederatedTokenAuthenticator.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureKeyVaultClient\Authentication;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use JsonException;
+use Keboola\AzureKeyVaultClient\Exception\ClientException;
+use Keboola\AzureKeyVaultClient\Exception\InvalidResponseException;
+use Keboola\AzureKeyVaultClient\GuzzleClientFactory;
+use Psr\Log\LoggerInterface;
+
+class FederatedTokenAuthenticator implements AuthenticatorInterface
+{
+    private const ENV_AZURE_TENANT_ID = 'AZURE_TENANT_ID';
+    private const ENV_AZURE_CLIENT_ID = 'AZURE_CLIENT_ID';
+    private const ENV_AZURE_FEDERATED_TOKEN_FILE = 'AZURE_FEDERATED_TOKEN_FILE';
+    private const ENV_AZURE_AUTHORITY_HOST = 'AZURE_AUTHORITY_HOST';
+
+    private const DEFAULT_AZURE_AUTHORITY_HOST = 'https://login.microsoftonline.com';
+
+    // Buffer time in seconds before token expiration to refresh the token
+    private const TOKEN_REFRESH_BUFFER = 300; // 5 minutes
+
+    private Client $client;
+    private LoggerInterface $logger;
+
+    private string $tenantId;
+    private string $clientId;
+    private string $federatedTokenFile;
+    private string $resource;
+    private string $authorityHost;
+    private ?string $cachedToken;
+    private ?int $tokenExpiresAt;
+
+    public function __construct(GuzzleClientFactory $clientFactory, string $resource, array $options = [])
+    {
+        $this->logger = $clientFactory->getLogger();
+        $this->resource = $resource;
+
+        $this->tenantId = (string) getenv(self::ENV_AZURE_TENANT_ID);
+        $this->clientId = (string) getenv(self::ENV_AZURE_CLIENT_ID);
+        $this->federatedTokenFile = (string) getenv(self::ENV_AZURE_FEDERATED_TOKEN_FILE);
+
+        // Allow overriding the authority host
+        $this->authorityHost = (string) getenv(self::ENV_AZURE_AUTHORITY_HOST);
+        if (!$this->authorityHost) {
+            $this->authorityHost = self::DEFAULT_AZURE_AUTHORITY_HOST;
+            $this->logger->debug(
+                self::ENV_AZURE_AUTHORITY_HOST . ' environment variable is not specified, falling back to default.',
+            );
+        }
+        $this->authorityHost = rtrim($this->authorityHost, '/');
+
+        // Initialize client with the base authority host
+        $this->client = $clientFactory->getClient($this->authorityHost, $options);
+        $this->cachedToken = null;
+        $this->tokenExpiresAt = null;
+    }
+
+    public function getAuthenticationToken(): string
+    {
+        if ($this->shouldRefreshToken()) {
+            $this->cachedToken = $this->authenticate();
+        }
+
+        assert($this->cachedToken !== null);
+        return $this->cachedToken;
+    }
+
+    public function checkUsability(): void
+    {
+        $errors = [];
+        foreach ([
+            self::ENV_AZURE_TENANT_ID,
+            self::ENV_AZURE_CLIENT_ID,
+            self::ENV_AZURE_FEDERATED_TOKEN_FILE,
+        ] as $envVar) {
+            if (!getenv($envVar)) {
+                $errors[] = sprintf('Environment variable "%s" is not set.', $envVar);
+            }
+        }
+        if ($errors) {
+            throw new ClientException(implode(' ', $errors));
+        }
+
+        if (!file_exists($this->federatedTokenFile)) {
+            throw new ClientException(sprintf('Federated token file "%s" does not exist.', $this->federatedTokenFile));
+        }
+    }
+
+    private function shouldRefreshToken(): bool
+    {
+        // If no token or expiration time is set, consider it expired
+        if ($this->cachedToken === null || $this->tokenExpiresAt === null) {
+            return true;
+        }
+
+        // Check if token is expired or will expire within the buffer time
+        $currentTime = time();
+        return $currentTime >= ($this->tokenExpiresAt - self::TOKEN_REFRESH_BUFFER);
+    }
+
+    private function authenticate(): string
+    {
+        try {
+            $federatedToken = @file_get_contents($this->federatedTokenFile);
+            if ($federatedToken === false) {
+                throw new ClientException(sprintf(
+                    'Failed to read federated token from file "%s"',
+                    $this->federatedTokenFile,
+                ));
+            }
+
+            $response = $this->client->post(
+                sprintf('%s/%s/oauth2/v2.0/token', $this->authorityHost, $this->tenantId),
+                [
+                    'form_params' => [
+                        'grant_type' => 'client_credentials',
+                        'client_id' => $this->clientId,
+                        'client_assertion' => $federatedToken,
+                        'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+                        'scope' => $this->resource . '/.default',
+                    ],
+                    'headers' => [
+                        'Content-type' => 'application/x-www-form-urlencoded',
+                    ],
+                ],
+            );
+            $data = (array) json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+            if (empty($data['access_token']) || !is_scalar($data['access_token'])) {
+                throw new InvalidResponseException('Access token not provided in response: ' . json_encode($data));
+            }
+
+            // Store the token expiration time
+            if (isset($data['expires_in']) && is_numeric($data['expires_in'])) {
+                $this->tokenExpiresAt = time() + (int) $data['expires_in'];
+                $this->logger->debug(sprintf(
+                    'Token will expire at %s (in %d seconds)',
+                    date('Y-m-d H:i:s', $this->tokenExpiresAt),
+                    (int) $data['expires_in'],
+                ));
+            } else {
+                // If no expiration time is provided, set a default of 1 hour
+                $this->tokenExpiresAt = time() + 3600;
+                $this->logger->debug('No expiration time provided in token response, using default of 1 hour');
+            }
+
+            $this->logger->info('Successfully authenticated using federated token.');
+            return (string) $data['access_token'];
+        } catch (JsonException | GuzzleException $e) {
+            throw new ClientException('Failed to get authentication token: ' . $e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/tests/Authentication/FederatedTokenAuthenticatorTest.php
+++ b/tests/Authentication/FederatedTokenAuthenticatorTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\AzureKeyVaultClient\Tests\Authentication;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -57,8 +55,8 @@ class FederatedTokenAuthenticatorTest extends BaseTest
             'https://vault.azure.net',
         );
         putenv('AZURE_TENANT_ID=');
-        self::expectException(ClientException::class);
-        self::expectExceptionMessage('Environment variable "AZURE_TENANT_ID" is not set.');
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Environment variable "AZURE_TENANT_ID" is not set.');
         $authenticator->checkUsability();
     }
 
@@ -69,8 +67,8 @@ class FederatedTokenAuthenticatorTest extends BaseTest
             'https://vault.azure.net',
         );
         putenv('AZURE_CLIENT_ID=');
-        self::expectException(ClientException::class);
-        self::expectExceptionMessage('Environment variable "AZURE_CLIENT_ID" is not set.');
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Environment variable "AZURE_CLIENT_ID" is not set.');
         $authenticator->checkUsability();
     }
 
@@ -81,8 +79,8 @@ class FederatedTokenAuthenticatorTest extends BaseTest
             'https://vault.azure.net',
         );
         putenv('AZURE_FEDERATED_TOKEN_FILE=');
-        self::expectException(ClientException::class);
-        self::expectExceptionMessage('Environment variable "AZURE_FEDERATED_TOKEN_FILE" is not set.');
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Environment variable "AZURE_FEDERATED_TOKEN_FILE" is not set.');
         $authenticator->checkUsability();
     }
 
@@ -98,8 +96,8 @@ class FederatedTokenAuthenticatorTest extends BaseTest
             'https://vault.azure.net',
         );
 
-        self::expectException(ClientException::class);
-        self::expectExceptionMessage('Federated token file "/non-existent-file" does not exist.');
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Federated token file "/non-existent-file" does not exist.');
         $authenticator->checkUsability();
     }
 
@@ -267,8 +265,8 @@ class FederatedTokenAuthenticatorTest extends BaseTest
             ['handler' => $handlerStack],
         );
 
-        self::expectException(ClientException::class);
-        self::expectExceptionMessage('Failed to get authentication token: Token request failed');
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Failed to get authentication token: Token request failed');
         $authenticator->getAuthenticationToken();
     }
 
@@ -296,8 +294,8 @@ class FederatedTokenAuthenticatorTest extends BaseTest
             ['handler' => $handlerStack],
         );
 
-        self::expectException(InvalidResponseException::class);
-        self::expectExceptionMessage(
+        $this->expectException(InvalidResponseException::class);
+        $this->expectExceptionMessage(
             'Access token not provided in response: {"token_type":"Bearer","expires_in":3600}',
         );
         $authenticator->getAuthenticationToken();

--- a/tests/Authentication/FederatedTokenAuthenticatorTest.php
+++ b/tests/Authentication/FederatedTokenAuthenticatorTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AzureKeyVaultClient\Tests\Authentication;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Keboola\AzureKeyVaultClient\Authentication\FederatedTokenAuthenticator;
+use Keboola\AzureKeyVaultClient\Exception\ClientException;
+use Keboola\AzureKeyVaultClient\Exception\InvalidResponseException;
+use Keboola\AzureKeyVaultClient\GuzzleClientFactory;
+use Keboola\AzureKeyVaultClient\Tests\BaseTest;
+use Psr\Log\NullLogger;
+use Psr\Log\Test\TestLogger;
+use ReflectionClass;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class FederatedTokenAuthenticatorTest extends BaseTest
+{
+    private const TEST_FEDERATED_TOKEN = 'test-federated-token';
+    private const TEST_FEDERATED_TOKEN_FILE = '/tmp/test-federated-token.txt';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Set up the federated token file
+        file_put_contents(self::TEST_FEDERATED_TOKEN_FILE, self::TEST_FEDERATED_TOKEN);
+
+        // Set the environment variable for the federated token file
+        putenv('AZURE_FEDERATED_TOKEN_FILE=' . self::TEST_FEDERATED_TOKEN_FILE);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Clean up the test file
+        if (file_exists(self::TEST_FEDERATED_TOKEN_FILE)) {
+            unlink(self::TEST_FEDERATED_TOKEN_FILE);
+        }
+    }
+
+    public function testCheckUsabilityFailureMissingTenant(): void
+    {
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+        );
+        putenv('AZURE_TENANT_ID=');
+        self::expectException(ClientException::class);
+        self::expectExceptionMessage('Environment variable "AZURE_TENANT_ID" is not set.');
+        $authenticator->checkUsability();
+    }
+
+    public function testCheckUsabilityFailureMissingClient(): void
+    {
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+        );
+        putenv('AZURE_CLIENT_ID=');
+        self::expectException(ClientException::class);
+        self::expectExceptionMessage('Environment variable "AZURE_CLIENT_ID" is not set.');
+        $authenticator->checkUsability();
+    }
+
+    public function testCheckUsabilityFailureMissingFederatedTokenFile(): void
+    {
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+        );
+        putenv('AZURE_FEDERATED_TOKEN_FILE=');
+        self::expectException(ClientException::class);
+        self::expectExceptionMessage('Environment variable "AZURE_FEDERATED_TOKEN_FILE" is not set.');
+        $authenticator->checkUsability();
+    }
+
+    public function testCheckUsabilityFailureFederatedTokenFileNotFound(): void
+    {
+        // Set up required environment variables
+        putenv('AZURE_TENANT_ID=test-tenant');
+        putenv('AZURE_CLIENT_ID=test-client');
+        putenv('AZURE_FEDERATED_TOKEN_FILE=/non-existent-file');
+
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+        );
+
+        self::expectException(ClientException::class);
+        self::expectExceptionMessage('Federated token file "/non-existent-file" does not exist.');
+        $authenticator->checkUsability();
+    }
+
+    public function testValidEnvironmentSettings(): void
+    {
+        $logger = new TestLogger();
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory($logger),
+            'https://vault.azure.net',
+        );
+        $authenticator->checkUsability();
+        self::assertTrue($logger->hasDebugThatContains(
+            'AZURE_AUTHORITY_HOST environment variable is not specified, falling back to default.',
+        ));
+    }
+
+    public function testValidFullEnvironmentSettings(): void
+    {
+        putenv('AZURE_AUTHORITY_HOST=https://login.example.com');
+        $logger = new TestLogger();
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory($logger),
+            'https://vault.azure.net',
+        );
+        $authenticator->checkUsability();
+        self::assertFalse($logger->hasDebugThatContains(
+            'AZURE_AUTHORITY_HOST environment variable is not specified, falling back to default.',
+        ));
+    }
+
+    public function testAuthenticate(): void
+    {
+        // Set up required environment variables
+        putenv('AZURE_TENANT_ID=test-tenant');
+        putenv('AZURE_CLIENT_ID=test-client');
+        putenv('AZURE_FEDERATED_TOKEN_FILE=' . self::TEST_FEDERATED_TOKEN_FILE);
+
+        // Create a mock handler for the token request
+        $mockHandler = new MockHandler([
+            new Response(200, [], (string) json_encode([
+                'access_token' => 'test-access-token',
+                'expires_in' => 3600,
+                'token_type' => 'Bearer',
+            ])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $container = [];
+        $history = Middleware::history($container);
+        $handlerStack->push($history);
+
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+            ['handler' => $handlerStack],
+        );
+
+        $token = $authenticator->getAuthenticationToken();
+        self::assertSame('test-access-token', $token);
+
+        // Verify the request
+        self::assertCount(1, $container);
+        $request = $container[0]['request'];
+        self::assertInstanceOf(Request::class, $request);
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame(
+            'https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token',
+            (string) $request->getUri(),
+        );
+        self::assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+
+        // Verify the request body is properly URL-encoded with exact values
+        $requestBody = (string) $request->getBody();
+        parse_str($requestBody, $parsedBody);
+        self::assertSame([
+            'grant_type' => 'client_credentials',
+            'client_id' => 'test-client',
+            'client_assertion' => self::TEST_FEDERATED_TOKEN,
+            'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+            'scope' => 'https://vault.azure.net/.default',
+        ], $parsedBody);
+    }
+
+    public function testAuthenticateWithCustomAuthorityHost(): void
+    {
+        putenv('AZURE_AUTHORITY_HOST=https://login.example.com');
+        putenv('AZURE_TENANT_ID=test-tenant');
+        putenv('AZURE_CLIENT_ID=test-client');
+        putenv('AZURE_FEDERATED_TOKEN_FILE=' . self::TEST_FEDERATED_TOKEN_FILE);
+
+        // Create a mock handler for the token request
+        $mockHandler = new MockHandler([
+            new Response(
+                200,
+                [
+                    'Content-Type' => 'application/json',
+                ],
+                (string) json_encode([
+                    'token_type' => 'Bearer',
+                    'expires_in' => 3600,
+                    'ext_expires_in' => 3600,
+                    'expires_on' => '1589810452',
+                    'not_before' => '1589806552',
+                    'resource' => 'https://vault.azure.net',
+                    'access_token' => 'ey....ey',
+                ]),
+            ),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $container = [];
+        $history = Middleware::history($container);
+        $handlerStack->push($history);
+
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+            ['handler' => $handlerStack],
+        );
+
+        $token = $authenticator->getAuthenticationToken();
+        self::assertSame('ey....ey', $token);
+
+        // Verify the request
+        self::assertCount(1, $container);
+        $request = $container[0]['request'];
+        self::assertInstanceOf(Request::class, $request);
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://login.example.com/test-tenant/oauth2/v2.0/token', (string) $request->getUri());
+        self::assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+
+        // Verify the request body is properly URL-encoded with exact values
+        $requestBody = (string) $request->getBody();
+        parse_str($requestBody, $parsedBody);
+        self::assertSame([
+            'grant_type' => 'client_credentials',
+            'client_id' => 'test-client',
+            'client_assertion' => self::TEST_FEDERATED_TOKEN,
+            'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+            'scope' => 'https://vault.azure.net/.default',
+        ], $parsedBody);
+    }
+
+    public function testAuthenticateTokenError(): void
+    {
+        // Set up required environment variables
+        putenv('AZURE_TENANT_ID=test-tenant');
+        putenv('AZURE_CLIENT_ID=test-client');
+        putenv('AZURE_FEDERATED_TOKEN_FILE=' . self::TEST_FEDERATED_TOKEN_FILE);
+
+        // Create a mock handler that throws an exception
+        $mockHandler = new MockHandler([
+            new RequestException(
+                'Token request failed',
+                new Request('POST', 'https://example.com'),
+                new Response(400),
+            ),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+            ['handler' => $handlerStack],
+        );
+
+        self::expectException(ClientException::class);
+        self::expectExceptionMessage('Failed to get authentication token: Token request failed');
+        $authenticator->getAuthenticationToken();
+    }
+
+    public function testAuthenticateTokenMalformed(): void
+    {
+        // Set up required environment variables
+        putenv('AZURE_TENANT_ID=test-tenant');
+        putenv('AZURE_CLIENT_ID=test-client');
+        putenv('AZURE_FEDERATED_TOKEN_FILE=' . self::TEST_FEDERATED_TOKEN_FILE);
+
+        // Create a mock handler with malformed response
+        $mockHandler = new MockHandler([
+            new Response(200, [], (string) json_encode([
+                'token_type' => 'Bearer',
+                'expires_in' => 3600,
+                // Missing access_token
+            ])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+            ['handler' => $handlerStack],
+        );
+
+        self::expectException(InvalidResponseException::class);
+        self::expectExceptionMessage(
+            'Access token not provided in response: {"token_type":"Bearer","expires_in":3600}',
+        );
+        $authenticator->getAuthenticationToken();
+    }
+
+    public function testTokenExpiration(): void
+    {
+        // Set up required environment variables
+        putenv('AZURE_TENANT_ID=test-tenant');
+        putenv('AZURE_CLIENT_ID=test-client');
+        putenv('AZURE_FEDERATED_TOKEN_FILE=' . self::TEST_FEDERATED_TOKEN_FILE);
+
+        // Create a mock handler for the token request
+        $mockHandler = new MockHandler([
+            new Response(200, [], (string) json_encode([
+                'access_token' => 'test-access-token-1',
+                'expires_in' => 3600,
+                'token_type' => 'Bearer',
+            ])),
+            new Response(200, [], (string) json_encode([
+                'access_token' => 'test-access-token-2',
+                'expires_in' => 3600,
+                'token_type' => 'Bearer',
+            ])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $container = [];
+        $history = Middleware::history($container);
+        $handlerStack->push($history);
+
+        $authenticator = new FederatedTokenAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+            ['handler' => $handlerStack],
+        );
+
+        // First call should get the token
+        $token1 = $authenticator->getAuthenticationToken();
+        self::assertSame('test-access-token-1', $token1);
+
+        // Second call should use the cached token
+        $token2 = $authenticator->getAuthenticationToken();
+        self::assertSame('test-access-token-1', $token2);
+
+        // Verify only one request was made
+        self::assertCount(1, $container);
+
+        // Now let's simulate token expiration by modifying the tokenExpiresAt property
+        $reflection = new ReflectionClass($authenticator);
+        $property = $reflection->getProperty('tokenExpiresAt');
+        $property->setAccessible(true);
+        $property->setValue($authenticator, time() - 1); // Set expiration to the past
+
+        // Third call should get a new token
+        $token3 = $authenticator->getAuthenticationToken();
+        self::assertSame('test-access-token-2', $token3);
+
+        // Verify two requests were made
+        self::assertCount(2, $container);
+    }
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-82

Pridani podpory pro Federated token auth pres OIDC - budeme vyuzivat v no-dind jobech pro service-container aby nemel staticky credentials, ale pritom ostatni containery z Podu nemely ke KV pristup.

S implementaci jsem si moc nehral, nechal jsem to vyprdnou Cursor podle toho, jak vypadaji ty existujici authenticatory. Mam to ale e2e otestovany skrze daemona na CI clusteru v jobu, ze to funguje.

Pro zajimavost tady je WIP nastrel, jak to pak bude napojeny v daemonovi https://github.com/keboola/job-queue-daemon/pull/630