### PR TITLE
feat: Allow newer logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,13 @@
         "php": ">=8.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.5",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "symfony/config": "^5.0|^6.0",
         "symfony/validator": "^5.0|^6.0"
     },
     "require-dev": {
         "keboola/coding-standard": ">=14.0",
+        "monolog/monolog": "^3.9",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpstan/phpstan-symfony": "^1.2",

--- a/tests/Authentication/AuthenticationFactoryTest.php
+++ b/tests/Authentication/AuthenticationFactoryTest.php
@@ -16,8 +16,9 @@ use Keboola\AzureKeyVaultClient\Authentication\ClientCredentialsEnvironmentAuthe
 use Keboola\AzureKeyVaultClient\Authentication\ManagedCredentialsAuthenticator;
 use Keboola\AzureKeyVaultClient\GuzzleClientFactory;
 use Keboola\AzureKeyVaultClient\Tests\BaseTest;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use Psr\Log\NullLogger;
-use Psr\Log\Test\TestLogger;
 
 class AuthenticationFactoryTest extends BaseTest
 {
@@ -35,7 +36,9 @@ class AuthenticationFactoryTest extends BaseTest
     {
         /* Even if the instance metadata is not available, the managed credentials authenticator is
             returned because it's verification is optimized out */
-        $logger = new TestLogger();
+        $logsHandler = new TestHandler();
+        $logger = new Logger('test', [$logsHandler]);
+
         $mock = $this->createMock(Client::class);
         $mock->method('get')
             ->with('/metadata?api-version=2019-11-01&format=text')
@@ -52,7 +55,7 @@ class AuthenticationFactoryTest extends BaseTest
         $authenticationFactory = new AuthenticatorFactory();
         $authenticator = $authenticationFactory->getAuthenticator($factoryMock, 'https://vault.azure.net');
         self::assertInstanceOf(ManagedCredentialsAuthenticator::class, $authenticator);
-        self::assertTrue($logger->hasDebugThatContains(
+        self::assertTrue($logsHandler->hasDebugThatContains(
             'ClientCredentialsEnvironmentAuthenticator is not usable: ' .
             'Environment variable "AZURE_TENANT_ID" is not set.',
         ));

--- a/tests/Authentication/FederatedTokenAuthenticatorTest.php
+++ b/tests/Authentication/FederatedTokenAuthenticatorTest.php
@@ -15,8 +15,9 @@ use Keboola\AzureKeyVaultClient\Exception\ClientException;
 use Keboola\AzureKeyVaultClient\Exception\InvalidResponseException;
 use Keboola\AzureKeyVaultClient\GuzzleClientFactory;
 use Keboola\AzureKeyVaultClient\Tests\BaseTest;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use Psr\Log\NullLogger;
-use Psr\Log\Test\TestLogger;
 use ReflectionClass;
 
 /**
@@ -103,13 +104,16 @@ class FederatedTokenAuthenticatorTest extends BaseTest
 
     public function testValidEnvironmentSettings(): void
     {
-        $logger = new TestLogger();
+
+        $logsHandler = new TestHandler();
+        $logger = new Logger('test', [$logsHandler]);
+
         $authenticator = new FederatedTokenAuthenticator(
             new GuzzleClientFactory($logger),
             'https://vault.azure.net',
         );
         $authenticator->checkUsability();
-        self::assertTrue($logger->hasDebugThatContains(
+        self::assertTrue($logsHandler->hasDebugThatContains(
             'AZURE_AUTHORITY_HOST environment variable is not specified, falling back to default.',
         ));
     }
@@ -117,13 +121,16 @@ class FederatedTokenAuthenticatorTest extends BaseTest
     public function testValidFullEnvironmentSettings(): void
     {
         putenv('AZURE_AUTHORITY_HOST=https://login.example.com');
-        $logger = new TestLogger();
+
+        $logsHandler = new TestHandler();
+        $logger = new Logger('test', [$logsHandler]);
+
         $authenticator = new FederatedTokenAuthenticator(
             new GuzzleClientFactory($logger),
             'https://vault.azure.net',
         );
         $authenticator->checkUsability();
-        self::assertFalse($logger->hasDebugThatContains(
+        self::assertFalse($logsHandler->hasDebugThatContains(
             'AZURE_AUTHORITY_HOST environment variable is not specified, falling back to default.',
         ));
     }

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -12,9 +12,9 @@ use Keboola\AzureKeyVaultClient\Requests\EncryptDecryptRequest;
 use Keboola\AzureKeyVaultClient\Requests\EncryptRequest;
 use Keboola\AzureKeyVaultClient\Requests\SecretAttributes;
 use Keboola\AzureKeyVaultClient\Requests\SetSecretRequest;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use Psr\Log\Test\TestLogger;
 use RuntimeException;
 
 class ClientFunctionalTest extends TestCase
@@ -52,7 +52,7 @@ class ClientFunctionalTest extends TestCase
     public function testEncryptDecrypt(): void
     {
         $payload = ')_+\\(*&^%$#@!)/"\'junk';
-        $logger = new TestLogger();
+        $logger = new Logger('test');
         $client = new Client(
             new GuzzleClientFactory($logger),
             new AuthenticatorFactory(),
@@ -87,7 +87,7 @@ class ClientFunctionalTest extends TestCase
     public function testSetGetSecret(): void
     {
         $payload = ')_+\\(*&^%$#@!)/"\'junk';
-        $logger = new TestLogger();
+        $logger = new Logger('test');
         $client = new Client(
             new GuzzleClientFactory($logger),
             new AuthenticatorFactory(),
@@ -107,7 +107,7 @@ class ClientFunctionalTest extends TestCase
     public function testGetSecretDefaultVersion(): void
     {
         $payload = ')_+\\(*&^%$#@!)/"\'junk';
-        $logger = new TestLogger();
+        $logger = new Logger('test');
         $client = new Client(
             new GuzzleClientFactory($logger),
             new AuthenticatorFactory(),


### PR DESCRIPTION
Povoleni `psr/log: 1.1|^2.0|^3.0`. Kod zavisi jen na `LoggerInterface`, takze by nemel byt problem s kompatibilitou.

Podobne jak https://github.com/keboola/platform-libraries/pull/384